### PR TITLE
Initialize VS Code highlighting extension.

### DIFF
--- a/syntax/vscode/.gitignore
+++ b/syntax/vscode/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.vsix

--- a/syntax/vscode/.vscode/launch.json
+++ b/syntax/vscode/.vscode/launch.json
@@ -1,0 +1,17 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ]
+        }
+    ]
+}

--- a/syntax/vscode/.vscode/launch.json
+++ b/syntax/vscode/.vscode/launch.json
@@ -1,3 +1,18 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // A launch configuration that launches the extension inside a new window
 // Use IntelliSense to learn about possible attributes.
 // Hover to view descriptions of existing attributes.

--- a/syntax/vscode/.vscodeignore
+++ b/syntax/vscode/.vscodeignore
@@ -1,0 +1,4 @@
+.vscode/**
+.vscode-test/**
+.src/**
+.gitignore

--- a/syntax/vscode/.vscodeignore
+++ b/syntax/vscode/.vscodeignore
@@ -2,3 +2,4 @@
 .vscode-test/**
 .src/**
 .gitignore
+DEV.md

--- a/syntax/vscode/CHANGELOG.md
+++ b/syntax/vscode/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to the "logica-syntax-highlighting" extension will be documented in this file.
+
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## [Unreleased]
+
+- Initial release

--- a/syntax/vscode/DEV.md
+++ b/syntax/vscode/DEV.md
@@ -1,0 +1,65 @@
+
+# Development Instructions
+
+## Installation
+
+You can install this extension in Marketplace; or you can package the extension (as instructed below) and install the `vsix` file. 
+
+Alternatively, you can also copy the directory to your extension folder:
+```
+mkdir ~/.vscode/extensions/logica-syntax-highlighting-0.0.1
+cp -r syntaxes package.json language-configuration.json ~/.vscode/extensions/logica-syntax-highlighting-0.0.1
+```
+
+## Quick Running
+
+In VS Code open this folder and 
+
+- press `F5` to open a new window with the extension loaded; OR
+- hit `Ctrl+Shift+P` and run `>Debug: Start Debugging` in the Command Palette; OR
+- click `Run and Debug` on your VS Code activity bar and then click the `Start Debugging` icon.
+
+## Development
+
+Install `js-yaml` as a development only dependency in the extension:
+
+```
+npm install js-yaml --save-dev
+```
+
+Edit `src/logica.tmLanguage.yaml`, which is written in TextMate grammar.
+
+Convert `yaml` to `json` with the command-line tool:
+
+```
+npx js-yaml src/logica.tmLanguage.yaml > syntaxes/logica.tmLanguage.json
+```
+
+
+## Packaging and publishing
+
+Install `vsce` on your machine:
+
+```
+npm install -g vsce
+```
+
+Your account needs to be added to our Azure DevOps organization `logicalang` and publisher `Logica` (due to some [bugs](https://stackoverflow.com/questions/56032912/vs-marketplace-add-member-displayes-invalid-domain-error) adding to publisher needs Microsoft support). Then generate a personal access token as described [here](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#publishing-extensions). 
+
+Login your account with the access token:
+```
+vsce login <Your Account>
+```
+
+Generate a package and publish it (change `package.json` if needed):
+```
+vsce package
+vsce publish
+```
+
+
+## References
+
+https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide
+
+https://macromates.com/manual/en/language_grammars

--- a/syntax/vscode/README.md
+++ b/syntax/vscode/README.md
@@ -1,0 +1,32 @@
+# logica-syntax-highlighting README
+
+## Quick Running
+
+In VS Code open this folder and press `F5` to open a new window with the extension loaded.
+
+## Development
+
+Install `js-yaml` as a development only dependency in the extension:
+
+```
+npm install js-yaml --save-dev
+```
+
+Edit `src/logica.tmLanguage.yaml`, which is written in TextMate grammar.
+
+Convert `yaml` to `json` with the command-line tool:
+
+```
+npx js-yaml src/logica.tmLanguage.yaml > syntaxes/logica.tmLanguage.json
+```
+
+
+## Installation
+
+To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
+
+## References
+
+https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide
+
+https://macromates.com/manual/en/language_grammars

--- a/syntax/vscode/README.md
+++ b/syntax/vscode/README.md
@@ -30,7 +30,7 @@ npx js-yaml src/logica.tmLanguage.yaml > syntaxes/logica.tmLanguage.json
 To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
 
 ```
-mkdir ~/.vscode/extensions/logica-syntax-highlighting-0.0.1
+mkdir -p ~/.vscode/extensions/logica-syntax-highlighting-0.0.1
 cp -r syntaxes package.json language-configuration.json ~/.vscode/extensions/logica-syntax-highlighting-0.0.1
 ```
 

--- a/syntax/vscode/README.md
+++ b/syntax/vscode/README.md
@@ -2,7 +2,11 @@
 
 ## Quick Running
 
-In VS Code open this folder and press `F5` to open a new window with the extension loaded.
+In VS Code open this folder and 
+
+- press `F5` to open a new window with the extension loaded; OR
+- hit `Ctrl+Shift+P` and run `>Debug: Start Debugging` in the Command Palette; OR
+- click `Run and Debug` on your VS Code activity bar and then click the `Start Debugging` icon.
 
 ## Development
 
@@ -24,6 +28,11 @@ npx js-yaml src/logica.tmLanguage.yaml > syntaxes/logica.tmLanguage.json
 ## Installation
 
 To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
+
+```
+mkdir ~/.vscode/extensions/logica-syntax-highlighting-0.0.1
+cp -r syntaxes package.json language-configuration.json ~/.vscode/extensions/logica-syntax-highlighting-0.0.1
+```
 
 ## References
 

--- a/syntax/vscode/README.md
+++ b/syntax/vscode/README.md
@@ -1,41 +1,5 @@
 # logica-syntax-highlighting README
 
-## Quick Running
+## Introduction
 
-In VS Code open this folder and 
-
-- press `F5` to open a new window with the extension loaded; OR
-- hit `Ctrl+Shift+P` and run `>Debug: Start Debugging` in the Command Palette; OR
-- click `Run and Debug` on your VS Code activity bar and then click the `Start Debugging` icon.
-
-## Development
-
-Install `js-yaml` as a development only dependency in the extension:
-
-```
-npm install js-yaml --save-dev
-```
-
-Edit `src/logica.tmLanguage.yaml`, which is written in TextMate grammar.
-
-Convert `yaml` to `json` with the command-line tool:
-
-```
-npx js-yaml src/logica.tmLanguage.yaml > syntaxes/logica.tmLanguage.json
-```
-
-
-## Installation
-
-To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
-
-```
-mkdir -p ~/.vscode/extensions/logica-syntax-highlighting-0.0.1
-cp -r syntaxes package.json language-configuration.json ~/.vscode/extensions/logica-syntax-highlighting-0.0.1
-```
-
-## References
-
-https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide
-
-https://macromates.com/manual/en/language_grammars
+A syntax highlighting extension for Logica, a logic programming language that compiles to StandardSQL and runs on Google BigQuery. 

--- a/syntax/vscode/language-configuration.json
+++ b/syntax/vscode/language-configuration.json
@@ -1,0 +1,30 @@
+{
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "//",
+        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+        "blockComment": [ "/*", "*/" ]
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ],
+    // symbols that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/syntax/vscode/language-configuration.json
+++ b/syntax/vscode/language-configuration.json
@@ -1,3 +1,18 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments

--- a/syntax/vscode/package-lock.json
+++ b/syntax/vscode/package-lock.json
@@ -1,0 +1,53 @@
+{
+    "name": "logica-syntax-highlighting",
+    "version": "0.0.1",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "logica-syntax-highlighting",
+            "version": "0.0.1",
+            "devDependencies": {
+                "js-yaml": "^4.1.0"
+            },
+            "engines": {
+                "vscode": "^1.55.0"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        }
+    },
+    "dependencies": {
+        "argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "requires": {
+                "argparse": "^2.0.1"
+            }
+        }
+    }
+}

--- a/syntax/vscode/package.json
+++ b/syntax/vscode/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "logica-syntax-highlighting",
+    "displayName": "Logica Syntax Highlighting",
+    "description": "Syntax highlighting for Logica",
+    "version": "0.0.1",
+    "engines": {
+        "vscode": "^1.55.0"
+    },
+    "categories": [
+        "Programming Languages"
+    ],
+    "contributes": {
+        "languages": [
+            {
+                "id": "logica",
+                "aliases": [
+                    "Logica",
+                    "logica"
+                ],
+                "extensions": [
+                    ".l"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "logica",
+                "scopeName": "source.logica",
+                "path": "./syntaxes/logica.tmLanguage.json"
+            }
+        ]
+    },
+    "devDependencies": {
+        "js-yaml": "^4.1.0"
+    }
+}

--- a/syntax/vscode/package.json
+++ b/syntax/vscode/package.json
@@ -4,7 +4,7 @@
     "description": "Syntax highlighting for Logica",
     "version": "0.0.1",
     "engines": {
-        "vscode": "^1.55.0"
+        "vscode": "^1.54.0"
     },
     "categories": [
         "Programming Languages"
@@ -33,5 +33,10 @@
     },
     "devDependencies": {
         "js-yaml": "^4.1.0"
+    },
+    "publisher": "Logica",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/EvgSkv/logica.git"
     }
 }

--- a/syntax/vscode/src/logica.tmLanguage.yaml
+++ b/syntax/vscode/src/logica.tmLanguage.yaml
@@ -1,0 +1,403 @@
+---
+"$schema": https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json
+name: Logica
+patterns:
+  - include: "#program"
+  - include: "#temporary_operators"
+
+repository:
+  # This entry is added temporarily to make the highlighting work.
+  temporary_operators:
+    patterns:
+      - name: keyword.operator.arithmetic.logica
+        match: "@"
+      - name: keyword.operator.spread.logica
+        match: "\\.\\."
+      - name: keyword.operator.assignment.logica
+        match: "(:-|:=)"
+      - name: keyword.control.flow.logica
+        match: "\\bcombine\\b"
+      - include: "#negation"
+  
+  expression:
+    patterns:
+      # - include: "#combine"
+      - include: "#string_literal"
+      - include: "#number_literal"
+      - include: "#boolean_literal"
+      - include: "#null_literal"
+      - include: "#list"
+      - include: "#inclusion"
+      - include: "#implication"
+      - include: "#unary_operator_call"
+      - include: "#binary_operator_call"
+      - include: "#record"
+      - include: "#call"
+      - include: "#temporary_operators"
+      - begin: "\\("
+        end: "\\)"
+        beginCaptures:
+          '0': {name: "punctuation.parenthesis.begin.logica"}
+        endCaptures:
+          '0': {name: "punctuation.parenthesis.end.logica"}
+        patterns:
+          - include: "#expression"
+
+
+  string_literal:
+    name: string.quoted.double.logica
+    begin: "\""
+    end: "\""
+    patterns:
+      - name: constant.character.escape.logica
+        match: \\.
+  
+  number_literal:
+    patterns:
+      - name: constant.numeric.float.logica
+        match: |
+          (?x)
+            (?<! \w)
+            (?:
+              \. (?: [0-9] )+
+              |
+              (?: [0-9] )+ \. (?: [0-9] )+
+              |
+              (?: [0-9] )+ \.
+            )\b
+      - name: constant.numeric.dec.logica
+        match: |
+          (?x)
+            (?<![\w\.])(?:
+                [1-9](?: [0-9] )*
+                |
+                0+
+            )\b 
+  
+  boolean_literal: 
+    name: constant.language.logica
+    match: \b(true|false)\b
+  
+  null_literal:
+    name: constant.language.logica
+    match: \b(null)\b
+  
+  list:
+    begin: \[
+    end: \]
+    beginCaptures:
+      '0': {name: punctuation.definition.list.begin.logica}
+    endCaptures:
+      '0': {name: punctuation.definition.list.end.logica}
+    patterns:
+      - name: punctuation.separator.element.logica
+        match: ","
+      - include: "#expression"
+  
+  inclusion:
+    patterns:
+      - name: keyword.operator.logical.logica
+        match: \bin\b
+      # - include: "#expression"
+  
+  implication:
+    # begin: \(
+    # end: \)
+    # beginCaptures:
+    #   '0': {name: "punctuation.parenthesis.begin.logica"}
+    # endCaptures:
+    #   '0': {name: "punctuation.parenthesis.end.logica"}
+    patterns:
+      - name: keyword.operator.logical.logica
+        match: \b(if|else|then)\b
+      # - include: "#expression"
+  
+  # variable:
+  #   # match: \[a-z_][a-z0-9_]*
+  #   # name: "variable.parameter.logica"
+  #   patterns:
+  #     - include: "#field"
+  
+  field:
+    match: "\\b(?<!@)[A-Za-z_]\\w*\\b(?=[:?])"
+    name: "variable.parameter.logica"
+  
+  record_field_value:
+    patterns:
+      - include: "#field"
+      - name: punctuation.separator.colon.logica
+        match: ":"
+      - include: "#expression"
+  
+  record_internal:
+    patterns:
+      - name: keyword.operator.spread.logica
+        match: (?<!\.)\.\.(?!\.)
+      - name: punctuation.separator.element.logica
+        match: ","
+      - include: "#record_field_value"
+      # - include: "#variable"
+  
+  aggregating_field_value:
+    patterns:
+      - include: "#field"
+      - match: "\\?"
+        name: keyword.operator.logica
+      - include: "#aggregating_assignment"
+  
+  aggregating_record_internal:
+    patterns:
+      - name: punctuation.separator.element.logica
+        match: ","
+      - include: "#record_field_value"
+      - include: "#aggregating_field_value"
+  
+  record:
+    begin: "{"
+    end: "}"
+    beginCaptures:
+      '0': {name: punctuation.definition.dict.begin.logica}
+    endCaptures:
+      '0': {name: punctuation.definition.dict.end.logica}
+    patterns:
+      - include: "#record_internal"
+  
+  operator:
+    patterns:
+      - name: keyword.operator.logical.logica
+        match: (?x) ( && | \|\| )
+      - name: keyword.operator.comparison.logica
+        match: (?x) ( < | > | <= | >= | == | !=)
+      - name: keyword.operator.arithmetic.logica
+        match: (?x) (\+ | \* | \/ | \+\+ | \^ | ->)(?!=)
+        
+  unary_operator:
+    patterns:
+      - name: keyword.operator.logical.logica
+        match: \!(?!=)
+      - name: keyword.operator.arithmetic.logica
+        match: -(?!=)
+  
+  unary_operator_call:
+    patterns:
+      - include: "#unary_operator"
+      # - include: "#expression"
+  
+  binary_operator_call:
+    patterns:
+      - include: "#operator"
+      # - include: "#expression"
+
+  import:
+    patterns:
+      - begin: \b(?<!\.)(import)\b
+        end: $
+        beginCaptures:
+          '1': {name: keyword.control.import.logica}
+        patterns:
+          - match: |
+              (?x)
+                (?:.+)
+                \. 
+                (\w+)
+                \b(as)\b 
+                (\w+)
+            captures:
+              '1': {patterns: [{include: "#logica_predicate"}]}
+              '2': {name: keyword.control.import.logica}
+              '3': {patterns: [{include: "#logica_predicate"}]}
+          - match: |
+              (?x)
+                (?:.+)
+                \.
+                (\w+)
+            captures:
+              '1': {patterns: [{include: "#logica_predicate"}]}
+
+  # ordinary_logica_predicate:
+  #   match: "(?<!@)[A-Z_]\\w*"
+  #   name: "entity.name.function.logica"
+  
+  # imperative_predicate:
+  #   match: "(@)(\\w*)"
+  #   captures:
+  #     '1': {name: keyword.operator.arithmetic.logica}
+  #     '2': {name: entity.name.function.logica}
+  
+  logica_predicate:
+    match: |
+      (?x) 
+        (?<!\w)
+        (?: (@) | ([A-Z_]))
+        (\w*)
+    captures:
+      '1': {name: keyword.operator.arithmetic.logica}
+      '2': {name: entity.name.function.logica}
+      '3': {name: entity.name.function.logica}
+  
+  other_predicate:
+    patterns:
+      - match: "`[^`]+`"
+        name: "string.interpolated.logica"
+      # - match: "[\\w.]+"
+      #   name: "variable.other.logica" # database tables
+  
+  predicate:
+    patterns:
+      - include: "#logica_predicate"
+      - include: "#other_predicate"
+    
+  call:
+    name: meta.function-call.logica
+    begin: |
+      (?x)
+        (?:
+          ([A-Z_]\w*) |
+          (
+            (?: `[^`]+`) | 
+            (?: [\w.]+)
+          )
+        )
+        (?<= [\w`])
+        (\()
+    end: (\))
+    beginCaptures:
+      '1': {name: entity.name.function.logica}
+      '2': {patterns: [{include: "#other_predicate"}]}
+      '3': {name: "punctuation.definition.arguments.begin.logica"}
+    endCaptures:
+      '1': {name: "punctuation.definition.arguments.end.logica"}
+    patterns:
+      - include: "#record_internal"
+  
+  head_call:
+    name: meta.function-call.logica
+    begin: |
+      (?x)
+        ([A-Z_]\w*)
+        (\()
+    end: (\))
+    beginCaptures:
+      '1': {patterns: [{include: "#logica_predicate"}]}
+      '3': {name: "punctuation.definition.arguments.begin.logica"}
+    endCaptures:
+      '1': {name: "punctuation.definition.arguments.end.logica"}
+    patterns:
+      - include: "#aggregating_record_internal"
+
+
+  assignment:
+    patterns:
+      - include: "#simple_assignment"
+      - include: "#aggregating_assignment"
+  
+  simple_assignment:
+    patterns:
+      - match: "="
+        name: "keyword.operator.assignment.logica"
+      - include: "#expression"
+  
+  aggregating_operator:
+    patterns:
+      - match: "\\+="
+        name: "keyword.operator.assignment.logica"
+      - match: "([A-Z_]\\w*)(=)"
+        captures:
+          '1': {name: entity.name.function.logica}
+          '2': {name: "keyword.operator.assignment.logica"}
+  
+  aggregating_assignment:
+    patterns:
+      - include: "#aggregating_operator"
+      - include: "#expression"
+  
+  proposition:
+    patterns:
+      - include: "#conjunction"
+      - include: "#disjunction"
+      - include: "#negation"
+      - include: "#call"
+      - include: "#binary_operator_call"
+      - include: "#unary_operator_call"
+      - include: "#assign_combination"
+      - include: "#inclusion"
+      - begin: "\\("
+        end: "\\)"
+        beginCaptures:
+          '0': {name: "punctuation.parenthesis.begin.logica"}
+        endCaptures:
+          '0': {name: "punctuation.parenthesis.end.logica"}
+        patterns:
+          - include: "#proposition"
+  
+  conjunction:
+    patterns:
+      - name: punctuation.separator.element.logica
+        match: ","
+  
+  disjunction:
+    patterns:
+      - name: keyword.operator.logical.logica
+        match: "\\|"
+  
+  negation:
+    name: keyword.operator.logical.logica
+    match: "~"
+  
+  program: 
+    patterns:
+      - include: "#program_entry"
+      - name: punctuation.terminator.statement.logica
+        match: ";"
+      - include: "#comment"
+
+  program_entry:
+    patterns:
+    - include: "#import"
+    - include: "#rule"
+  
+  rule:
+    patterns:
+      - include: "#rule_head"
+      - match: ":-"
+        name: "keyword.operator.assignment.logica"
+      - include: "#rule_body"
+  
+  rule_body:
+    patterns:
+      - include: "#proposition"
+  
+  rule_head:
+    patterns:
+      - include: "#head_call"
+      - include: "#assignment"
+      - match: (?x)\b distinct \b
+        name: "keyword.control.flow.logica"
+
+
+  comment:
+    patterns:
+    - include: "#inline_comment"
+    - include: "#block_comment"
+  inline_comment:
+    patterns:
+    - name: comment.line.number-sign.logica
+      begin: \s*+(#)
+      beginCaptures:
+        '1':
+          name: punctuation.definition.comment.logica
+      end: "$"
+  block_comment:
+    name: comment.block.logica
+    begin: \s*+(\/\*)
+    beginCaptures:
+      '1':
+        name: punctuation.definition.comment.begin.logica
+    end: (\*\/)
+    endCaptures:
+      '1':
+        name: punctuation.definition.comment.end.logica
+
+  
+
+scopeName: source.logica

--- a/syntax/vscode/src/logica.tmLanguage.yaml
+++ b/syntax/vscode/src/logica.tmLanguage.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 "$schema": https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json
 name: Logica

--- a/syntax/vscode/src/logica.tmLanguage.yaml
+++ b/syntax/vscode/src/logica.tmLanguage.yaml
@@ -369,6 +369,7 @@ repository:
   program_entry:
     patterns:
     - include: "#import"
+    - include: "#functor_application"
     - include: "#rule"
   
   rule:
@@ -388,7 +389,34 @@ repository:
       - include: "#assignment"
       - match: (?x)\b distinct \b
         name: "keyword.control.flow.logica"
-
+  
+  functor_application:
+    begin: |
+      (?x)
+        ([A-Z_]\w*)
+        (?: \s*)
+        (:=)
+        (?: \s*)
+        ([A-Z_]\w*)
+        (\()
+    end: (\))
+    beginCaptures:
+      '1': {name: entity.name.function.logica}
+      '2': {name: keyword.operator.assignment.logica}
+      '3': {name: entity.name.function.logica}
+      '4': {name: "punctuation.definition.arguments.begin.logica"}
+    endCaptures:
+      '1': {name: "punctuation.definition.arguments.end.logica"}
+    patterns:
+      - include: "#functor_record_internal"
+  
+  functor_record_internal:
+    patterns:
+      - name: punctuation.separator.colon.logica
+        match: ":"
+      - name: punctuation.separator.element.logica
+        match: ","
+      - include: "#logica_predicate"
 
   comment:
     patterns:

--- a/syntax/vscode/syntaxes/logica.tmLanguage.json
+++ b/syntax/vscode/syntaxes/logica.tmLanguage.json
@@ -1,0 +1,649 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Logica",
+  "patterns": [
+    {
+      "include": "#program"
+    },
+    {
+      "include": "#temporary_operators"
+    }
+  ],
+  "repository": {
+    "temporary_operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.arithmetic.logica",
+          "match": "@"
+        },
+        {
+          "name": "keyword.operator.spread.logica",
+          "match": "\\.\\."
+        },
+        {
+          "name": "keyword.operator.assignment.logica",
+          "match": "(:-|:=)"
+        },
+        {
+          "name": "keyword.control.flow.logica",
+          "match": "\\bcombine\\b"
+        },
+        {
+          "include": "#negation"
+        }
+      ]
+    },
+    "expression": {
+      "patterns": [
+        {
+          "include": "#string_literal"
+        },
+        {
+          "include": "#number_literal"
+        },
+        {
+          "include": "#boolean_literal"
+        },
+        {
+          "include": "#null_literal"
+        },
+        {
+          "include": "#list"
+        },
+        {
+          "include": "#inclusion"
+        },
+        {
+          "include": "#implication"
+        },
+        {
+          "include": "#unary_operator_call"
+        },
+        {
+          "include": "#binary_operator_call"
+        },
+        {
+          "include": "#record"
+        },
+        {
+          "include": "#call"
+        },
+        {
+          "include": "#temporary_operators"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.parenthesis.begin.logica"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.parenthesis.end.logica"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#expression"
+            }
+          ]
+        }
+      ]
+    },
+    "string_literal": {
+      "name": "string.quoted.double.logica",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.logica",
+          "match": "\\\\."
+        }
+      ]
+    },
+    "number_literal": {
+      "patterns": [
+        {
+          "name": "constant.numeric.float.logica",
+          "match": "(?x)\n  (?<! \\w)\n  (?:\n    \\. (?: [0-9] )+\n    |\n    (?: [0-9] )+ \\. (?: [0-9] )+\n    |\n    (?: [0-9] )+ \\.\n  )\\b\n"
+        },
+        {
+          "name": "constant.numeric.dec.logica",
+          "match": "(?x)\n  (?<![\\w\\.])(?:\n      [1-9](?: [0-9] )*\n      |\n      0+\n  )\\b \n"
+        }
+      ]
+    },
+    "boolean_literal": {
+      "name": "constant.language.logica",
+      "match": "\\b(true|false)\\b"
+    },
+    "null_literal": {
+      "name": "constant.language.logica",
+      "match": "\\b(null)\\b"
+    },
+    "list": {
+      "begin": "\\[",
+      "end": "\\]",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.list.begin.logica"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.list.end.logica"
+        }
+      },
+      "patterns": [
+        {
+          "name": "punctuation.separator.element.logica",
+          "match": ","
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "inclusion": {
+      "patterns": [
+        {
+          "name": "keyword.operator.logical.logica",
+          "match": "\\bin\\b"
+        }
+      ]
+    },
+    "implication": {
+      "patterns": [
+        {
+          "name": "keyword.operator.logical.logica",
+          "match": "\\b(if|else|then)\\b"
+        }
+      ]
+    },
+    "variable": {
+      "patterns": [
+        {
+          "include": "#field"
+        }
+      ]
+    },
+    "field": {
+      "match": "\\b(?<!@)[A-Za-z_]\\w*\\b(?=[:?])",
+      "name": "variable.parameter.logica"
+    },
+    "record_field_value": {
+      "patterns": [
+        {
+          "include": "#field"
+        },
+        {
+          "name": "punctuation.separator.colon.logica",
+          "match": ":"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "record_internal": {
+      "patterns": [
+        {
+          "name": "keyword.operator.spread.logica",
+          "match": "(?<!\\.)\\.\\.(?!\\.)"
+        },
+        {
+          "name": "punctuation.separator.element.logica",
+          "match": ","
+        },
+        {
+          "include": "#record_field_value"
+        }
+      ]
+    },
+    "aggregating_field_value": {
+      "patterns": [
+        {
+          "include": "#field"
+        },
+        {
+          "match": "\\?",
+          "name": "keyword.operator.logica"
+        },
+        {
+          "include": "#aggregating_assignment"
+        }
+      ]
+    },
+    "aggregating_record_internal": {
+      "patterns": [
+        {
+          "name": "punctuation.separator.element.logica",
+          "match": ","
+        },
+        {
+          "include": "#record_field_value"
+        },
+        {
+          "include": "#aggregating_field_value"
+        }
+      ]
+    },
+    "record": {
+      "begin": "{",
+      "end": "}",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.dict.begin.logica"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.dict.end.logica"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#record_internal"
+        }
+      ]
+    },
+    "operator": {
+      "patterns": [
+        {
+          "name": "keyword.operator.logical.logica",
+          "match": "(?x) ( && | \\|\\| )"
+        },
+        {
+          "name": "keyword.operator.comparison.logica",
+          "match": "(?x) ( < | > | <= | >= | == | !=)"
+        },
+        {
+          "name": "keyword.operator.arithmetic.logica",
+          "match": "(?x) (\\+ | \\* | \\/ | \\+\\+ | \\^ | ->)(?!=)"
+        }
+      ]
+    },
+    "unary_operator": {
+      "patterns": [
+        {
+          "name": "keyword.operator.logical.logica",
+          "match": "\\!(?!=)"
+        },
+        {
+          "name": "keyword.operator.arithmetic.logica",
+          "match": "-(?!=)"
+        }
+      ]
+    },
+    "unary_operator_call": {
+      "patterns": [
+        {
+          "include": "#unary_operator"
+        }
+      ]
+    },
+    "binary_operator_call": {
+      "patterns": [
+        {
+          "include": "#operator"
+        }
+      ]
+    },
+    "import": {
+      "patterns": [
+        {
+          "begin": "\\b(?<!\\.)(import)\\b",
+          "end": "$",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.import.logica"
+            }
+          },
+          "patterns": [
+            {
+              "match": "(?x)\n  (?:.+)\n  \\. \n  (\\w+)\n  \\b(as)\\b \n  (\\w+)\n",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#logica_predicate"
+                    }
+                  ]
+                },
+                "2": {
+                  "name": "keyword.control.import.logica"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "include": "#logica_predicate"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "match": "(?x)\n  (?:.+)\n  \\.\n  (\\w+)\n",
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#logica_predicate"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "logica_predicate": {
+      "match": "(?x) \n  (?<!\\w)\n  (?: (@) | ([A-Z_]))\n  (\\w*)\n",
+      "captures": {
+        "1": {
+          "name": "keyword.operator.arithmetic.logica"
+        },
+        "2": {
+          "name": "entity.name.function.logica"
+        },
+        "3": {
+          "name": "entity.name.function.logica"
+        }
+      }
+    },
+    "other_predicate": {
+      "patterns": [
+        {
+          "match": "`[^`]+`",
+          "name": "string.interpolated.logica"
+        }
+      ]
+    },
+    "predicate": {
+      "patterns": [
+        {
+          "include": "#logica_predicate"
+        },
+        {
+          "include": "#other_predicate"
+        }
+      ]
+    },
+    "call": {
+      "name": "meta.function-call.logica",
+      "begin": "(?x)\n  (?:\n    ([A-Z_]\\w*) |\n    (\n      (?: `[^`]+`) | \n      (?: [\\w.]+)\n    )\n  )\n  (?<= [\\w`])\n  (\\()\n",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.logica"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#other_predicate"
+            }
+          ]
+        },
+        "3": {
+          "name": "punctuation.definition.arguments.begin.logica"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.arguments.end.logica"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#record_internal"
+        }
+      ]
+    },
+    "head_call": {
+      "name": "meta.function-call.logica",
+      "begin": "(?x)\n  ([A-Z_]\\w*)\n  (\\()\n",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#logica_predicate"
+            }
+          ]
+        },
+        "3": {
+          "name": "punctuation.definition.arguments.begin.logica"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.arguments.end.logica"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#aggregating_record_internal"
+        }
+      ]
+    },
+    "assignment": {
+      "patterns": [
+        {
+          "include": "#simple_assignment"
+        },
+        {
+          "include": "#aggregating_assignment"
+        }
+      ]
+    },
+    "simple_assignment": {
+      "patterns": [
+        {
+          "match": "=",
+          "name": "keyword.operator.assignment.logica"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "aggregating_operator": {
+      "patterns": [
+        {
+          "match": "\\+=",
+          "name": "keyword.operator.assignment.logica"
+        },
+        {
+          "match": "([A-Z_]\\w*)(=)",
+          "captures": {
+            "1": {
+              "name": "entity.name.function.logica"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.logica"
+            }
+          }
+        }
+      ]
+    },
+    "aggregating_assignment": {
+      "patterns": [
+        {
+          "include": "#aggregating_operator"
+        },
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "proposition": {
+      "patterns": [
+        {
+          "include": "#conjunction"
+        },
+        {
+          "include": "#disjunction"
+        },
+        {
+          "include": "#negation"
+        },
+        {
+          "include": "#call"
+        },
+        {
+          "include": "#binary_operator_call"
+        },
+        {
+          "include": "#unary_operator_call"
+        },
+        {
+          "include": "#assign_combination"
+        },
+        {
+          "include": "#inclusion"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.parenthesis.begin.logica"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.parenthesis.end.logica"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#proposition"
+            }
+          ]
+        }
+      ]
+    },
+    "conjunction": {
+      "patterns": [
+        {
+          "name": "punctuation.separator.element.logica",
+          "match": ","
+        }
+      ]
+    },
+    "disjunction": {
+      "patterns": [
+        {
+          "name": "keyword.operator.logical.logica",
+          "match": "\\|"
+        }
+      ]
+    },
+    "negation": {
+      "name": "keyword.operator.logical.logica",
+      "match": "~"
+    },
+    "program": {
+      "patterns": [
+        {
+          "include": "#program_entry"
+        },
+        {
+          "name": "punctuation.terminator.statement.logica",
+          "match": ";"
+        },
+        {
+          "include": "#comment"
+        }
+      ]
+    },
+    "program_entry": {
+      "patterns": [
+        {
+          "include": "#import"
+        },
+        {
+          "include": "#rule"
+        }
+      ]
+    },
+    "rule": {
+      "patterns": [
+        {
+          "include": "#rule_head"
+        },
+        {
+          "match": ":-",
+          "name": "keyword.operator.assignment.logica"
+        },
+        {
+          "include": "#rule_body"
+        }
+      ]
+    },
+    "rule_body": {
+      "patterns": [
+        {
+          "include": "#proposition"
+        }
+      ]
+    },
+    "rule_head": {
+      "patterns": [
+        {
+          "include": "#head_call"
+        },
+        {
+          "include": "#assignment"
+        },
+        {
+          "match": "(?x)\\b distinct \\b",
+          "name": "keyword.control.flow.logica"
+        }
+      ]
+    },
+    "comment": {
+      "patterns": [
+        {
+          "include": "#inline_comment"
+        },
+        {
+          "include": "#block_comment"
+        }
+      ]
+    },
+    "inline_comment": {
+      "patterns": [
+        {
+          "name": "comment.line.number-sign.logica",
+          "begin": "\\s*+(#)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.comment.logica"
+            }
+          },
+          "end": "$"
+        }
+      ]
+    },
+    "block_comment": {
+      "name": "comment.block.logica",
+      "begin": "\\s*+(\\/\\*)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.begin.logica"
+        }
+      },
+      "end": "(\\*\\/)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.end.logica"
+        }
+      }
+    }
+  },
+  "scopeName": "source.logica"
+}

--- a/syntax/vscode/syntaxes/logica.tmLanguage.json
+++ b/syntax/vscode/syntaxes/logica.tmLanguage.json
@@ -162,13 +162,6 @@
         }
       ]
     },
-    "variable": {
-      "patterns": [
-        {
-          "include": "#field"
-        }
-      ]
-    },
     "field": {
       "match": "\\b(?<!@)[A-Za-z_]\\w*\\b(?=[:?])",
       "name": "variable.parameter.logica"
@@ -566,6 +559,9 @@
           "include": "#import"
         },
         {
+          "include": "#functor_application"
+        },
+        {
           "include": "#rule"
         }
       ]
@@ -602,6 +598,49 @@
         {
           "match": "(?x)\\b distinct \\b",
           "name": "keyword.control.flow.logica"
+        }
+      ]
+    },
+    "functor_application": {
+      "begin": "(?x)\n  ([A-Z_]\\w*)\n  (?: \\s*)\n  (:=)\n  (?: \\s*)\n  ([A-Z_]\\w*)\n  (\\()\n",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.logica"
+        },
+        "2": {
+          "name": "keyword.operator.assignment.logica"
+        },
+        "3": {
+          "name": "entity.name.function.logica"
+        },
+        "4": {
+          "name": "punctuation.definition.arguments.begin.logica"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.arguments.end.logica"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#functor_record_internal"
+        }
+      ]
+    },
+    "functor_record_internal": {
+      "patterns": [
+        {
+          "name": "punctuation.separator.colon.logica",
+          "match": ":"
+        },
+        {
+          "name": "punctuation.separator.element.logica",
+          "match": ","
+        },
+        {
+          "include": "#logica_predicate"
         }
       ]
     },


### PR DESCRIPTION
This is the initial version of the VS Code highlighting extension. Here I try to structure the TextMate grammar file in the BNF way, but I've made simplifications here and there to produce a basic version for a start. Instructions on quick running, development and installation can be found in `README.md`.