### PR TITLE
Avoid splitting statements in RunSQL on SQLite. 

### DIFF
--- a/colab_logica.py
+++ b/colab_logica.py
@@ -147,12 +147,12 @@ def RunSQL(sql, engine, connection=None, is_final=False):
     else:
       return connection.execute(sql)
   elif engine == 'sqlite':
-    statements = parse.SplitRaw(sql, ';')
-    connection.executescript(sql)
+    # TODO: Verify Logica never generates more than one statement.
+    # statements = parse.SplitRaw(sql, ';')
     if is_final:
-      return pandas.read_sql(statements[-1], connection)
+      return pandas.read_sql(sql, connection)
     else:
-      pass
+      connection.executescript(sql)
     return None
   else:
     raise Exception('Logica only supports BigQuery, PostgreSQL and SQLite '

--- a/colab_logica.py
+++ b/colab_logica.py
@@ -155,9 +155,9 @@ def RunSQL(sql, engine, connection=None, is_final=False):
       else:
         connection.executescript(sql)
     except Exception as e:
-      print("--- SQL ---")
+      print("\n--- SQL ---")
       print(sql)
-      ShowError("Error while executing SQL:", str(e))
+      ShowError("Error while executing SQL: %s" % e)
     return None
   else:
     raise Exception('Logica only supports BigQuery, PostgreSQL and SQLite '

--- a/colab_logica.py
+++ b/colab_logica.py
@@ -147,10 +147,9 @@ def RunSQL(sql, engine, connection=None, is_final=False):
     else:
       return connection.execute(sql)
   elif engine == 'sqlite':
-    # TODO: Verify Logica never generates more than one statement.
-    # statements = parse.SplitRaw(sql, ';')
     try:
       if is_final:
+        # For final predicates this SQL is always a single statement.
         return pandas.read_sql(sql, connection)
       else:
         connection.executescript(sql)

--- a/colab_logica.py
+++ b/colab_logica.py
@@ -157,7 +157,8 @@ def RunSQL(sql, engine, connection=None, is_final=False):
     except Exception as e:
       print("\n--- SQL ---")
       print(sql)
-      ShowError("Error while executing SQL: %s" % e)
+      ShowError("Error while executing SQL:\n%s" % e)
+      raise e
     return None
   else:
     raise Exception('Logica only supports BigQuery, PostgreSQL and SQLite '

--- a/colab_logica.py
+++ b/colab_logica.py
@@ -149,10 +149,15 @@ def RunSQL(sql, engine, connection=None, is_final=False):
   elif engine == 'sqlite':
     # TODO: Verify Logica never generates more than one statement.
     # statements = parse.SplitRaw(sql, ';')
-    if is_final:
-      return pandas.read_sql(sql, connection)
-    else:
-      connection.executescript(sql)
+    try:
+      if is_final:
+        return pandas.read_sql(sql, connection)
+      else:
+        connection.executescript(sql)
+    except Exception as e:
+      print("--- SQL ---")
+      print(sql)
+      ShowError("Error while executing SQL:", str(e))
     return None
   else:
     raise Exception('Logica only supports BigQuery, PostgreSQL and SQLite '


### PR DESCRIPTION
The split is not required, as the final predicate is always a single statement.