### PR TITLE
Add a friendly error message for unexpected aggregation.

### DIFF
--- a/compiler/rule_translate.py
+++ b/compiler/rule_translate.py
@@ -483,7 +483,6 @@ def ExtractPredicateStructure(c, s):
       table_var = ExceptExpression.Build(table_name, field_value['except'])
     else:
       table_var = field_value['field']
-
     expr = field_value['value']['expression']
     var_name = s.allocator.AllocateVar('%s_%s' % (table_name, table_var))
     s.vars_map[table_name, table_var] = var_name

--- a/compiler/rule_translate.py
+++ b/compiler/rule_translate.py
@@ -483,6 +483,12 @@ def ExtractPredicateStructure(c, s):
       table_var = ExceptExpression.Build(table_name, field_value['except'])
     else:
       table_var = field_value['field']
+    
+    if 'expression' not in field_value['value']:
+      raise RuleCompileException(
+            color.Format('Aggregation the predicate calls in the body is impossible.'),
+            self.full_rule_text)
+
     expr = field_value['value']['expression']
     var_name = s.allocator.AllocateVar('%s_%s' % (table_name, table_var))
     s.vars_map[table_name, table_var] = var_name

--- a/compiler/rule_translate.py
+++ b/compiler/rule_translate.py
@@ -483,11 +483,6 @@ def ExtractPredicateStructure(c, s):
       table_var = ExceptExpression.Build(table_name, field_value['except'])
     else:
       table_var = field_value['field']
-    
-    if 'expression' not in field_value['value']:
-      raise RuleCompileException(
-            color.Format('Aggregation the predicate calls in the body is impossible.'),
-            self.full_rule_text)
 
     expr = field_value['value']['expression']
     var_name = s.allocator.AllocateVar('%s_%s' % (table_name, table_var))

--- a/parser_py/parse.py
+++ b/parser_py/parse.py
@@ -442,7 +442,8 @@ def ParseRecordInternals(s,
         if question_split:
           if not is_aggregation_allowed:
             raise ParsingException('Aggregation of fields is only allowed in the head '
-                                   'of a rule.')
+                                   'of a rule.',
+                                   field_value)
           positional_ok = False
           field, value = question_split
           observed_field = field


### PR DESCRIPTION
Raising the error at parsing time. Example of a code that gets the error:
```
Q(1) :- T(x? += 1);  # This makes no sense whatsoever.
```
