### PR TITLE
Migrate to modern testing library API

### DIFF
--- a/type_inference/tests/db_interaction_test.py
+++ b/type_inference/tests/db_interaction_test.py
@@ -61,8 +61,8 @@ class TestTypeInferenceWithSqlite(unittest.TestCase):
 
     TypeInference(graphs, sqlite_inspector).Infer()
 
-    self.assertEquals(q_col0.type, number)
-    self.assertEquals(t_col0.type, number)
+    self.assertEqual(q_col0.type, number)
+    self.assertEqual(t_col0.type, number)
 
     self.safe_drop_table('T')
 
@@ -110,8 +110,8 @@ class TestTypeInferenceWithPsql(unittest.TestCase):
 
     TypeInference(graphs, postgres_inspector).Infer()
 
-    self.assertEquals(q_col0.type, number)
-    self.assertEquals(t_col0.type, number)
+    self.assertEqual(q_col0.type, number)
+    self.assertEqual(t_col0.type, number)
 
     self.safe_drop_table(metadata, table)
 

--- a/type_inference/tests/intersection_test.py
+++ b/type_inference/tests/intersection_test.py
@@ -50,7 +50,7 @@ class IntersectionTest(unittest.TestCase):
     for type in types:
       with self.subTest(type=type):
         result = self.intersect_with_zero_bounds(Intersect, type, type)
-        self.assertEquals(result, type)
+        self.assertEqual(result, type)
 
   def test_fail_when_intersect_not_equal_types(self):
     types = [number, string, boolean, list_of_nums,


### PR DESCRIPTION
# PR Summary
This PR migrates from `unittest.assertEquals` to `unittest.assertEqual` which is deprecated from Python2.7:
```python
DeprecationWarning: Please use assertEqual instead.
```