### PR TITLE
Add Callclingo

### DIFF
--- a/common/callclingo.py
+++ b/common/callclingo.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+#
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides integration with Clingo (Answer Set Programming) for Logica."""
+
+import json
+
+try:
+    import clingo
+except ImportError as e:
+    raise ImportError(
+        "The 'clingo' Python package is required for ClingoToLogica. "
+        "Install it with: pip install clingo"
+    ) from e
+
+def _run_clingo(script: str):
+    """Execute a Clingo script and return the answer sets using the Clingo Python API."""
+    answer_sets = []
+
+    class Collector:
+        def __init__(self):
+            self.models = []
+
+        def on_model(self, model):
+            atoms = [str(atom) for atom in model.symbols(shown=True)]
+            self.models.append(atoms)
+
+    collector = Collector()
+    ctl = clingo.Control()
+    ctl.configuration.solve.models = 0  # 0 means all possible answer sets
+    try:
+        ctl.add("base", [], script)
+        ctl.ground([("base", [])])
+        ctl.solve(on_model=collector.on_model)
+    except Exception as e:
+        raise RuntimeError(f"Clingo execution failed: {e}")
+
+    # Convert answer sets to Logica-compatible format
+    for atoms in collector.models:
+        predicates = {}
+        for atom in atoms:
+            if '(' in atom:
+                pred_name, args_str = atom.split('(', 1)
+                args_str = args_str.rstrip(')')
+                args = []
+                for arg in args_str.split(','):
+                    arg = arg.strip()
+                    if arg.isdigit():
+                        args.append(int(arg))
+                    elif arg.startswith('"') and arg.endswith('"'):
+                        args.append(arg[1:-1])
+                    else:
+                        args.append(arg)
+                predicates[pred_name] = args
+            else:
+                predicates[atom] = []
+        answer_sets.append(predicates)
+
+    return answer_sets
+
+def ClingoToLogica(script: str) -> str:
+    """
+    Execute a Clingo script and return results as a list of possible worlds,
+    each with a world id and a list of predicate strings (e.g., 'attack(b,a)').
+    """
+    answer_sets = _run_clingo(script)
+    result = []
+    for idx, answer_set in enumerate(answer_sets, start=1):
+        predicates = []
+        for pred_name, args in answer_set.items():
+            if args:
+                # Join arguments with commas, wrap strings in quotes if needed
+                arg_strs = []
+                for arg in args:
+                    if isinstance(arg, str) and not arg.isdigit():
+                        arg_strs.append(str(arg))
+                    else:
+                        arg_strs.append(str(arg))
+                pred_str = f"{pred_name}({', '.join(arg_strs)})"
+            else:
+                pred_str = pred_name
+            predicates.append(pred_str)
+        result.append({"world_id": idx, "predicates": predicates})
+    return json.dumps(result) 

--- a/common/sqlite3_logica.py
+++ b/common/sqlite3_logica.py
@@ -13,8 +13,10 @@ import re
 
 if '.' not in __package__:
   from common import intelligence
+  from common import callclingo
 else:
   from ..common import intelligence
+  from ..common import callclingo
 
 
 def DeFactoType(value):
@@ -257,6 +259,7 @@ def ExtendConnectionWithLogicaFunctions(con):
   con.create_function('RE_SUB', 5, lambda string, pattern, repl="", count=0, flags=0: \
                                     re.sub(pattern, repl, string ,count, flags))
   con.create_function('Intelligence', 1, intelligence.Intelligence)
+  con.create_function('ClingoToLogica', 1, callclingo.ClingoToLogica)
   con.create_function('AssembleRecord', 1, AssembleRecord)
   con.create_function('DisassembleRecord', 1, DisassembleRecord)
   sqlite3.enable_callback_tracebacks(True)

--- a/compiler/dialect_libraries/sqlite_library.py
+++ b/compiler/dialect_libraries/sqlite_library.py
@@ -51,6 +51,8 @@ Fingerprint(s) = SqlExpr("Fingerprint({s})", {s:});
 
 Intelligence(command) = SqlExpr("Intelligence({command})", {command:});
 
+ClingoToLogica(script) = SqlExpr("ClingoToLogica({script})", {script:});
+
 AssembleRecord(field_values) = SqlExpr("AssembleRecord({field_values})", {field_values:});
 
 DisassembleRecord(record) = SqlExpr("DisassembleRecord({record})", {record:});


### PR DESCRIPTION
This PR introduces the `ClingoToLogica` function into Logica, enabling the parsing and analysis of Clingo outputs directly within Logica programs. This enhances Logica's capability to integrate with ASP-based workflows.

Below is a working example that demonstrates how Clingo output is parsed and translated into Logica predicates:

```
%%logica Predicate

@Engine("sqlite");

ClingoParse(x,y,z) :- json = ClingoToLogica("""
attack(b,a).
attack(c,b).
attack(e,b).
attack(f,b).
attack(v,b).
attack(w,b).
attack(y,b).
attack(d,c).
attack(q,c).
attack(z,c).
attack(e,d).
attack(x,d).
attack(m,e).
attack(i,e).
attack(s,e).
attack(h,f).
attack(s,f).
attack(q,g).
attack(q,h).
attack(j,i).
attack(k,i).
attack(l,i).
attack(o,i).
attack(n,j).
attack(o,m).
attack(m,n).
attack(m,o).
attack(g,s).
attack(t,s).
attack(b,t).
attack(u,t).
attack(v,u).

arg(X) :- attack(X,_).
arg(X) :- attack(_,X).


{ in(X) : arg(X) }.

% 1. Conflict-free: No two arguments in the extension attack each other
:- in(X), in(Y), attack(X,Y).

% 2. Stable: All arguments not in the extension must be attacked by at least one argument in the extension
:- arg(Y), not in(Y), not attacked(Y).

attacked(Y) :- in(X), attack(X,Y).
"""), x=json[0], y=x.world_id, z=x.predicates;


Predicate(name:m, args:l) :- ClingoParse(x,y,z), predicate in z, m=predicate.pred_name, l=predicate.args, m="in";
```

Example Output


| name | args   |
|------|--------|
| in   | ["e"]  |
| in   | ["f"]  |
| in   | ["v"]  |
| in   | ["w"]  |
| in   | ["y"]  |
| in   | ["q"]  |
| in   | ["z"]  |
| in   | ["x"]  |
| in   | ["k"]  |
| in   | ["l"]  |
| in   | ["o"]  |
| in   | ["n"]  |
| in   | ["t"]  |
| in   | ["a"]  |

