### PR TITLE
Suppress BrokenPipeError when printing results

### DIFF
--- a/logica.py
+++ b/logica.py
@@ -346,7 +346,10 @@ def main(argv):
         o, _ = p.communicate(formatted_sql.encode())
       else:
         assert False, 'Unknown engine: %s' % engine
-      print(o.decode())
+      try:
+          print(o.decode())
+      except BrokenPipeError:
+          pass
 
 
 def run_main():


### PR DESCRIPTION
This change prevents the following stacktrace from being printed when piping into the `head` command:

```
Traceback (most recent call last):
  File "/nix/store/3zj6dc0w3w57b2n7rncl3vjnzjnfbsa2-python3.12-logica-85797c731544f28c61947d2d7673adbbc578f547/bin/.logica-wrapped", line 9, in <module>
    sys.exit(run_main())
             ^^^^^^^^^^
  File "/nix/store/54lvq0bjb84dr9skzzy5h3lina4f0785-python3-3.12.8-env/lib/python3.12/site-packages/logica/logica.py", line 354, in run_main
    main(sys.argv)
  File "/nix/store/54lvq0bjb84dr9skzzy5h3lina4f0785-python3-3.12.8-env/lib/python3.12/site-packages/logica/logica.py", line 349, in main
    print(o.decode())
BrokenPipeError: [Errno 32] Broken pipe
```

The `head` command is handy when developing logica code that produces large tables.