### PR TITLE
Prevent error message when stdout is a pipe that has closed

### DIFF
--- a/logica.py
+++ b/logica.py
@@ -347,7 +347,7 @@ def main(argv):
       else:
         assert False, 'Unknown engine: %s' % engine
       try:
-          print(o.decode())
+          print(o.decode(), flush=True)
       except BrokenPipeError:
           pass
 


### PR DESCRIPTION
It turns out there was two different occurrences of `BrokenPipeError`:
1. When `logica.py` prints result into a closed pipe
    - Addressed in https://github.com/EvgSkv/logica/pull/487
    - Repeatable via `python3 logica.py - run_to_csv Q <<<'B(0);B(1);Q("asdfasdfasdfasdfasdf"):-B(a2),B(a4),B(a8),B(a16),B(a32),B(a64),B(a128),B(a256),B(a512),B(a1024),B(a2048),B(a5096)' | head -n 3`
2. When the pipe is closed while logica is doing something else
    - Explained further here https://stackoverflow.com/a/26738736
    - Repeatable via `python3 logica.py - run_to_csv Q <<<'B(0);B(1);Q(0):-B(a2),B(a4),B(a8),B(a16),B(a32),B(a64),B(a128),B(a256),B(a512),B(a1024),B(a2048),B(a5096)' | head -n 3`

This PR addressed 2